### PR TITLE
add ENV

### DIFF
--- a/ntpserver/Dockerfile
+++ b/ntpserver/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:latest
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update && apt-get install -y ntp && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 CMD ["/usr/sbin/ntpd", "-n"]


### PR DESCRIPTION
When install tzdata, which will stoped with interactive dialog.

https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai